### PR TITLE
Fix preferences window not working

### DIFF
--- a/main.js
+++ b/main.js
@@ -201,7 +201,10 @@ function showPreferencesWindow () {
     preferencesWindow = new BrowserWindow({
       width: 400,
       height: 300,
-      resizable: false
+      resizable: false,
+      webPreferences: {
+        nodeIntegration: true
+      }
     })
     preferencesWindow.loadURL(`file://${__dirname}/preferences.html`)
     preferencesWindow.show()


### PR DESCRIPTION
Node integration in web views was set to `false` in [electron 5.0](https://github.com/electron/electron/blob/master/docs/api/breaking-changes.md#new-browserwindow-webpreferences-) as part of a breaking change. Because of this change, a current build from source won't have a working preferences window.

I went ahead and set the option `nodeIntegration` to `true` to fix this issue. 