### PR TITLE
Add copy, paste and cut option to preferences window

### DIFF
--- a/main.js
+++ b/main.js
@@ -205,6 +205,19 @@ function showPreferencesWindow () {
     })
     preferencesWindow.loadURL(`file://${__dirname}/preferences.html`)
     preferencesWindow.show()
+    Menu.setApplicationMenu(Menu.buildFromTemplate(
+      [
+        { role: 'appMenu' },
+        {
+          role: 'editMenu',
+          submenu: [
+            { role: 'copy' },
+            { role: 'paste' },
+            { role: 'cut' },
+          ]
+        },
+      ])
+    )
   }
 }
 


### PR DESCRIPTION
In the current preferences window copy, paste or cut is not working.

Having to type the API-Key by hand may cause errors so I added a new application menu to the preferences window. Each submenu is set to the corresponding role, to make use of the native macOS functionality. 