### PR TITLE
Fix vulnerabilities by upgrading eslint-utils

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1436,9 +1436,9 @@
       }
     },
     "eslint-utils": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.0.tgz",
-      "integrity": "sha512-7ehnzPaP5IIEh1r1tkjuIrxqhNkzUJa9z3R92tLJdZIVdWaczEhr3EbhGtsMrVxi1KeR8qA7Off6SWc5WNQqyQ==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
+      "integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
       "dev": true,
       "requires": {
         "eslint-visitor-keys": "^1.0.0"


### PR DESCRIPTION
Hello, just found your project by Hacktoberfest retweet!
When I was installing the `npm` report vulnerabilities linked with `eslint-utils` so I just upgraded them.
I tried to run the app, but it seems it need valid project and api key in order to run it even in development mode, right? I believe this could make it harder to people contribute with the project 😢  Any thoughts on that?